### PR TITLE
Create Yae Fischl Aggravate

### DIFF
--- a/static/sheets/Yae Fischl Aggravate
+++ b/static/sheets/Yae Fischl Aggravate
@@ -1,0 +1,114 @@
+--
+title: Yae-Fischl Aggravate
+authors:
+  - Hikki#7589
+tags:
+  - Fischl
+  - Yae Miko
+  - Kaedehara Kazuha
+  - DMC
+  - Aggravate
+  - Quicken
+pros:
+  - Good in both Single Target and AoE content 
+  - Gets better with Gearing and Constellation 
+  - Good sustained DPS over the full rotation
+cons:
+  - Easily interruptible 
+  - no healing/shielding 
+Ratings:
+healing: 1
+shielding: 1
+difficulty: 3
+target: 2/3
+characters:
+  - name: Yae Miko
+    star: 5
+    constellation: 0
+    weapon: 
+      name: Kagura's Varity 
+      refinement: 1
+    artifacts:
+      - Gilded dreams
+    hp: 16689
+    atk: 1861
+    def: 679
+    em: 119
+    cr: 75.16%
+    cd: 182.40%
+    er: 144.08%
+    dps: 23664
+ - name: Fischl
+    star: 4
+    constellation: 6
+    weapon:
+      name: The Stringless
+      refinement: 5
+    artifacts:
+      - Thundersoother
+    hp: 15388
+    atk: 1705
+    def: 707
+    em: 205
+    cr: 54.65%
+    cd: 158.54%
+    er: 122.04%
+    dps: 19883
+ - name: Kaedehara Kazuha
+    star: 5
+    constellation: 0
+    weapon:
+      name: Xiphos' Moonlight
+      refinement: 1
+    artifacts:
+      - Viridescent Venerer
+    hp: 19960
+    atk: 1060
+    def: 946
+    em: 1039
+    cr: 24.86%
+    cd: 89.72%
+    er: 187%
+    dps: 7418
+ - name: DMC
+    star: 5
+    constellation:6
+    weapon:
+      name: Favonius Sword
+      refinement: 3
+    artifacts:
+      - Deepwood Memories
+    hp: 17242
+    atk: 1236
+    def: 807
+    em: 218
+    cr: 65.89%
+    cd: 63.24%
+    er: 246.16%
+    dps: 1847
+rotation:
+  duration: 22s
+  video_url: https://youtu.be/EpM_UtfTRhk
+---
+# **Notes**
+This calc is being made with keeping quite high investment in mind like Yae having Kagura and Kazuha having Xiphos' moonlight, on the flip side xiphos is only R1, so fav with high refinement(R3) will perform close enough to that and if we provide  Oathsworn Eye R5 to Yae instead then the team DPS becomes 'round bout 48k, which isn't much worse. Also ER requirement in the team is quite low because of xiphos+fav+electro resonance but I still have included more ER subs to neutralize the overall builds. Keep in mind this teams performance increases quite a bit with gearing and constellation. 
+
+# **Rotation Notes**
+   **First Rotation:**
+       Fischl E 
+       Kazuha hEp
+       Yae EEE
+       DMC E Q
+       Kazuha Q hEp
+       Fischl Q 
+       Yae Q 
+    **Subsequent Rotations:**
+        Yae EEE 
+        Kazuha hEp 
+        Fischl E 
+        DMC E Q 
+        Kazuha Q hEp 
+        Fischl Q 
+        Yae Q EEE
+
+Note - Rotations can change a lot with Widsith but sorry I don't know Widsith rotations as widsith buffs are often WAYTOODANK to calc Smh 


### PR DESCRIPTION
``---
title: Yae-Fischl Aggravate
authors:
  - Hikki#7589
tags:
  - Fischl
  - Yae Miko
  - Kaedehara Kazuha
  - DMC
  - Aggravate
  - Quicken
pros:
  - Good in both Single Target and AoE content 
  - Gets better with Gearing and Constellation 
  - Good sustained DPS over the full rotation
cons:
  - Easily interruptible 
  - no healing/shielding 
Ratings:
healing: 1
shielding: 1
difficulty: 3
target: 2/3
characters:
  - name: Yae Miko
    star: 5
    constellation: 0
    weapon: 
      name: Kagura's Varity 
      refinement: 1
    artifacts:
      - Gilded dreams
    hp: 16689
    atk: 1861
    def: 679
    em: 119
    cr: 75.16%
    cd: 182.40%
    er: 144.08%
    dps: 23664
 - name: Fischl
    star: 4
    constellation: 6
    weapon:
      name: The Stringless
      refinement: 5
    artifacts:
      - Thundersoother
    hp: 15388
    atk: 1705
    def: 707
    em: 205
    cr: 54.65%
    cd: 158.54%
    er: 122.04%
    dps: 19883
 - name: Kaedehara Kazuha
    star: 5
    constellation: 0
    weapon:
      name: Xiphos' Moonlight
      refinement: 1
    artifacts:
      - Viridescent Venerer
    hp: 19960
    atk: 1060
    def: 946
    em: 1039
    cr: 24.86%
    cd: 89.72%
    er: 187%
    dps: 7418
 - name: DMC
    star: 5
    constellation:6
    weapon:
      name: Favonius Sword
      refinement: 3
    artifacts:
      - Deepwood Memories
    hp: 17242
    atk: 1236
    def: 807
    em: 218
    cr: 65.89%
    cd: 63.24%
    er: 246.16%
    dps: 1847
rotation:
  duration: 22s
  video_url: https://youtu.be/EpM_UtfTRhk
---
# **Notes**
This calc is being made with keeping quite high investment in mind like Yae having Kagura and Kazuha having Xiphos' moonlight, on the flip side xiphos is only R1, so fav with high refinement(R3) will perform close enough to that and if we provide  Oathsworn Eye R5 to Yae instead then the team DPS becomes 'round bout 48k, which isn't much worse. Also ER requirement in the team is quite low because of xiphos+fav+electro resonance but I still have included more ER subs to neutralize the overall builds. Keep in mind this teams performance increases quite a bit with gearing and constellation. 

# **Rotation Notes**
   **First Rotation:**
       Fischl E 
       Kazuha hEp
       Yae EEE
       DMC E Q
       Kazuha Q hEp
       Fischl Q 
       Yae Q 
    **Subsequent Rotations:**
        Yae EEE 
        Kazuha hEp 
        Fischl E 
        DMC E Q 
        Kazuha Q hEp 
        Fischl Q 
        Yae Q EEE

Note - Rotations can change a lot with Widsith but sorry I don't know Widsith rotations as widsith buffs are often WAYTOODANK to calc Smh 